### PR TITLE
Handle usernames/passwords with strange characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ node {
             usernameVariable: 'DOCKERHUB_USERNAME'
         ]]
     ) {
-        sh "docker login -u ${env.DOCKERHUB_USERNAME} -p ${env.DOCKERHUB_PASSWORD} -e demo@mesosphere.com"
+        sh "docker login -u '${env.DOCKERHUB_USERNAME}' -p '${env.DOCKERHUB_PASSWORD}' -e demo@mesosphere.com"
         sh "docker push mesosphere/vny:${gitCommit()}"
     }
 }


### PR DESCRIPTION
Without the quotes I was getting:

```
/jenkins/workspace/****@tmp/durable-abcdef12/script.sh: line 2: syntax
error: EOF in backquote substitution
```

Because I had a ` in my generated password
